### PR TITLE
Fix: Crash when suspending & resuming App with active NativeAdView.

### DIFF
--- a/packages/firebase-admob/nativead/index.android.ts
+++ b/packages/firebase-admob/nativead/index.android.ts
@@ -28,7 +28,7 @@ export class NativeAdView extends NativeAdViewBase implements AddChildFromBuilde
 
 	onLoaded(){
 		super.onLoaded();
-		if(this.#child){
+		if(this.#child && this.#native.indexOfChild(this.#child.nativeView) === -1) {
 			(this.#native as any).addView(this.#child.nativeView);
 		}
 	}


### PR DESCRIPTION
Fix for 
```
System.err: An uncaught Exception occurred on "main" thread.
System.err: Calling js method onStart failed
System.err: Error: java.lang.IllegalStateException: The specified child already has a parent. You must call removeView() on the child's parent first.
System.err:
```