### PR TITLE
set iOS platform to 10 as needed for latest Firebase Pods

### DIFF
--- a/packages/firebase-core/platforms/ios/Podfile
+++ b/packages/firebase-core/platforms/ios/Podfile
@@ -1,4 +1,4 @@
-platform :ios, '9.0'
+platform :ios, '10.0'
 #pod 'Firebase/CoreOnly'
 
 


### PR DESCRIPTION
Updates to iOS platform 10 to solve the below error as directed by [Firebase docs](https://firebase.google.com/docs/ios/setup#add-sdks)

```
[!] CocoaPods could not find compatible versions for pod "Firebase/Functions":
  In Podfile:
    Firebase/Functions (~> 8.6)

Specs satisfying the `Firebase/Functions (~> 8.6)` dependency were found, but they required a higher minimum deployment target.
```


