### PR TITLE
Implement client-side Firebase Cloud Functions locations

### DIFF
--- a/packages/firebase-functions/README.md
+++ b/packages/firebase-functions/README.md
@@ -51,11 +51,7 @@ firebase()
 ## Regional Cloud Functions
 Cloud Functions are _regional_, which means the infrastructure that runs your Cloud Function is located in specific regions.
 
-<<<<<<< HEAD
 By default, functions run in the _us-central1_ region. View the [supported regions](https://firebase.google.com/docs/functions/locations).
-=======
-By default, functions run in the _us-central1_ region. View the [supported regions](https://firebase.google.com/docs/functions/locations)
->>>>>>> e0602081644464c60610caa66d227ba3dfcf2c57
 
 To run functions in a different region, after initializing Firebase App set the region using _firebase().app().functions(region)_.
 

--- a/packages/firebase-functions/README.md
+++ b/packages/firebase-functions/README.md
@@ -48,6 +48,41 @@ firebase()
 	});
 ```
 
+## Regional Cloud Functions
+Cloud Functions are _regional_, which means the infrastructure that runs your Cloud Function is located in specific regions.
+
+By default, functions run in the _us-central1_ region. View the [supported regions](https://firebase.google.com/docs/functions/locations).
+
+To run functions in a different region, after initializing Firebase App set the region using _firebase().app().functions(region)_.
+
+Regional function endpoint example (using _europe-west2_ region ):
+```ts
+// Deployed HTTPS callable
+exports.listProducts = functions.region("europe-west2").https.onCall(() => {
+	return [
+		/* ... */
+		// Return some data
+	];
+});
+```
+
+To access the regional function endpoint:
+```ts
+import { firebase } from '@nativescript/firebase-core';
+import '@nativescript/firebase-functions';
+
+firebase().initializeApp();
+firebase().app().functions("europe-west2");
+
+firebase()
+	.functions()
+	.httpsCallable('listProducts')()
+	.then((response) => {
+		setProducts(response.data);
+		setLoading(false);
+	});
+```
+
 ## Using an emulator
 
 Whilst developing your application with Cloud Functions, it is possible to run the functions inside of a local emulator.

--- a/packages/firebase-functions/index.d.ts
+++ b/packages/firebase-functions/index.d.ts
@@ -26,9 +26,22 @@ export declare class Functions implements IFunctions {
 }
 
 declare module '@nativescript/firebase-core' {
+
 	export interface Firebase extends FirebaseFunctions {}
+	// Add 'functions' method to FirebaseApp
+	export interface FirebaseApp extends FirebaseFunctionsApp {}
 }
 
 export interface FirebaseFunctions {
 	static functions(app?: FirebaseApp): Functions;
+}
+/**
+	Add Region (Android & iOS) or Custom Domain (iOS only) to Firebase Functions HTTPS call
+	@param regionOrCustomDomain (string) (optional): Region (Android or iOS) or Custom Domain (iOS only)
+	@return Functions
+	@see Supported Regions: https://firebase.google.com/docs/functions/locations
+	@example firebase().app().functions("us-central1")
+	*/
+export interface FirebaseFunctionsApp {
+	static functions(regionOrCustomDomain?: string): Functions;
 }


### PR DESCRIPTION
Add client-side location selection for callable functions.

Allow App functions to call Cloud Functions with a selectable Region (Android & iOS) or Custom Domain (iOS only); e.g. functions created for region "europe-west2".

Otherwise, all Firebase Functions calls are to the default "us-central1" region.