### PR TITLE
bug(analytics): add missing Firebase import from analytics index.d.ts

### DIFF
--- a/packages/firebase-analytics/index.d.ts
+++ b/packages/firebase-analytics/index.d.ts
@@ -1,4 +1,5 @@
-import { IAnalytics, EventParameter, ConsentType, ConsentStatus} from './common';
+import { IAnalytics, EventParameter, ConsentType, ConsentStatus } from './common';
+import { Firebase } from '@nativescript/firebase-core';
 
 export * from './common';
 


### PR DESCRIPTION
Ran into the following error when using the analytics plugin in a NativeScript Angular project in an Nx workspace.

```bash
Property 'analytics' does not exist on type 'Firebase'.ts(2339)
```

This happens when I try to access the `analytics` function from the `firebase` function.

```typescript
firebase().analytics()
```

This PR adds the missing `Firebase` import in the `firebase-analytics`'s `index.d.ts` file. :) 