### PR TITLE
bug(messaging): fix parsing remote message

### DIFF
--- a/packages/firebase-messaging/index.ios.ts
+++ b/packages/firebase-messaging/index.ios.ts
@@ -419,13 +419,13 @@ function parseRemoteMessage(remoteMessage: NSDictionary<any, any>) {
 		}
 
 		// message.sentTime
-		if ([key === 'google.c.a.ts']) {
+		if (key === 'google.c.a.ts') {
 			message['sentTime'] = remoteMessage.objectForKey(key);
 			continue;
 		}
 
 		// message.to
-		if ([key === 'to'] || [key === 'google.to']) {
+		if (key === 'to' || key === 'google.to') {
 			message['to'] = remoteMessage.objectForKey(key);
 			continue;
 		}


### PR DESCRIPTION
I have a custom "data" field which contains a "payload" object with additional data when I'm sending an FCM message. I noticed that the "payload" data didn't get parsed correctly in the `parseRemoteMessage` function which resulted in the entire "payload" data to be missing as it reaches the app.

Troubleshooting it further, I found that two of the `if` statements with square brackets is always returning `true` which resulted in the "payload" data being missing.