### PR TITLE
fix(crashlytics): set webpack alias for stacktrace-js

### DIFF
--- a/packages/firebase-crashlytics/nativescript.webpack.js
+++ b/packages/firebase-crashlytics/nativescript.webpack.js
@@ -1,0 +1,9 @@
+module.exports = webpack => {
+  webpack.chainWebpack((config) => {
+    // fix import path for stacktrace-js
+    config.resolve.alias.set(
+      "stacktrace-js",
+      "stacktrace-js/dist/stacktrace.js"
+    );
+  });
+}


### PR DESCRIPTION
This should fix errors produced when bundling crashlytics.

(need to pack locally and test - so setting as draft)