### PR TITLE
fix: use (anonymous) for empty functionNames when generating stack information in recordError()

### DIFF
--- a/packages/firebase-crashlytics/index.android.ts
+++ b/packages/firebase-crashlytics/index.android.ts
@@ -73,7 +73,7 @@ export class Crashlytics implements ICrashlytics {
 			StackTrace.fromError(error).then((stack) => {
 				const traceElements = Array.create('java.lang.StackTraceElement', stack.length);
 				stack.forEach((item, i) => {
-					traceElements[i] = new java.lang.StackTraceElement('', item.functionName, item.fileName, -1);
+					traceElements[i] = new java.lang.StackTraceElement('', item.functionName || '(anonymous)', item.fileName, -1);
 				});
 				const t = new java.lang.Throwable(error.message);
 				t.setStackTrace(traceElements);

--- a/packages/firebase-crashlytics/index.ios.ts
+++ b/packages/firebase-crashlytics/index.ios.ts
@@ -67,7 +67,7 @@ export class Crashlytics implements ICrashlytics {
 			StackTrace.fromError(error).then((stack) => {
 				const traceElements = [];
 				stack.forEach((item, i) => {
-					traceElements[i] = FIRStackFrame.stackFrameWithSymbolFileLine(item.functionName, item.fileName, item.lineNumber);
+					traceElements[i] = FIRStackFrame.stackFrameWithSymbolFileLine(item.functionName || '(anonymous)', item.fileName, item.lineNumber);
 				});
 				const e = FIRExceptionModel.exceptionModelWithNameReason('JavaScriptError', error.message);
 				this.native.recordExceptionModel(e);


### PR DESCRIPTION
If an Error's stack trace contains stack information about an arrow function `() => ...` then `stacktrace-js` will not create a `functionName` entry for that element. At least on Android, this leads to a runtime error.

Proposal: if the `functionName` is empty, use `(anonymous)` as the function name.

fixes #65