### PR TITLE
HttpsCallableResult has no "data" field

### DIFF
--- a/packages/firebase-functions/common.ts
+++ b/packages/firebase-functions/common.ts
@@ -24,9 +24,7 @@ export interface HttpsCallableOptions {
   timeout?: number;
 }
 
-export interface HttpsCallableResult {
-  readonly data: any;
-}
+export type HttpsCallableResult = any;
 
 
 export interface HttpsCallable {


### PR DESCRIPTION
As you can see.
- Android: resolve(deserialize(result?.getData?.()))
- iOS: resolve(deserialize(result.data))
