### PR TITLE
fix(messaging): prevent loss of messages when app is closed.

### DIFF
--- a/packages/firebase-messaging/src-native/android/messaging/src/main/java/org/nativescript/firebase/messaging/FirebaseMessaging.kt
+++ b/packages/firebase-messaging/src-native/android/messaging/src/main/java/org/nativescript/firebase/messaging/FirebaseMessaging.kt
@@ -62,7 +62,7 @@ class FirebaseMessaging {
         remoteMessage.notification?.let {
           remoteMessage.messageId?.let { messageId ->
             remoteMessageMap[messageId] = remoteMessage
-            preferences?.edit()?.putString(messageId, remoteMessageToJson(remoteMessage).toString())
+            preferences?.edit()?.putString(messageId, remoteMessageToJson(remoteMessage).toString())?.apply()
           }
         }
 


### PR DESCRIPTION
I believe that this solves the issue where if there are multiple notifications recieved when the app is closed, 
Clicking on the first notification opens the app and the app gets the message, but if you then close the app and then click the next notification the app does not recieve the events.

Note:  I'm not sure how you are producing the platforms/android/messaging-release.aar so I've only checked in the kotlin.

This is from this discussion:  https://discordapp.com/channels/603595811204366337/751068755206864916/954024742233464862
