### PR TITLE
fix(dynamic-links): prevent crash when annotation is null

### DIFF
--- a/packages/firebase-dynamic-links/platforms/ios/src/TNSFirebaseDynamicLinksAppDelegate.swift
+++ b/packages/firebase-dynamic-links/platforms/ios/src/TNSFirebaseDynamicLinksAppDelegate.swift
@@ -27,7 +27,7 @@ public class TNSFirebaseDynamicLinksAppDelegate: UIResponder , UIApplicationDele
     
     @objc public func application(_ app: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey : Any] = [:]) -> Bool {
         
-        return application(app, open: url, sourceApplication: options[UIApplication.OpenURLOptionsKey.sourceApplication] as? String, annotation: options[UIApplication.OpenURLOptionsKey.annotation]!)
+        return application(app, open: url, sourceApplication: options[UIApplication.OpenURLOptionsKey.sourceApplication] as? String, annotation: options[UIApplication.OpenURLOptionsKey.annotation])
     }
     
     @objc public func application(_ application: UIApplication, open url: URL, sourceApplication: String?, annotation: Any) -> Bool {


### PR DESCRIPTION
Apparently the options are always empty https://github.com/firebase/firebase-ios-sdk/blob/136e71f7aa438236421307a69c01789855515464/FirebaseDynamicLinks/Sources/FIRDynamicLinks.m#L544