### PR TITLE
fix(messaging): Typings for reexported Types that are used in the method definitions.

### DIFF
--- a/packages/firebase-messaging/index.d.ts
+++ b/packages/firebase-messaging/index.d.ts
@@ -1,6 +1,8 @@
 import { FirebaseApp, Firebase } from '@nativescript/firebase-core';
 
-export { Permissions, AndroidPermissions, IOSPermissions, AuthorizationStatus } from '@nativescript/firebase-messaging-core';
+export { AndroidPermissions, IOSPermissions } from '@nativescript/firebase-messaging-core';
+import { Permissions, AuthorizationStatus } from '@nativescript/firebase-messaging-core';
+export { Permissions, AuthorizationStatus };
 
 export enum NotificationAndroidVisibility {
 	VISIBILITY_PRIVATE,


### PR DESCRIPTION
Seems like it can't figure out the typings for things which are directly exported when they are used in the type definitions.
So need to import and then export.