### PR TITLE
fix(ios/core): filter out nil values from `serialize` method

### DIFF
--- a/packages/firebase-core/utils.ts
+++ b/packages/firebase-core/utils.ts
@@ -37,13 +37,13 @@ export function serialize(data: any, wrapPrimitives: boolean = false): any {
 				}
 
 				if (Array.isArray(data)) {
-					return NSArray.arrayWithArray(data.map((el) => serialize(el, wrapPrimitives)).filter((el) => el !== null && el !== NSNull.new()));
+					return NSArray.arrayWithArray(data.map((el) => serialize(el, wrapPrimitives)).filter((el) => el !== null));
 				}
 
 				const node = Object.fromEntries(
 					Object.entries(data)
 						.map(([key, value]) => [key, serialize(value, wrapPrimitives)])
-						.filter(([key, value]) => value !== null && value !== NSNull.new())
+						.filter(([, value]) => value !== null)
 				);
 
 				return NSDictionary.dictionaryWithDictionary(node);

--- a/packages/firebase-core/utils.ts
+++ b/packages/firebase-core/utils.ts
@@ -37,14 +37,15 @@ export function serialize(data: any, wrapPrimitives: boolean = false): any {
 				}
 
 				if (Array.isArray(data)) {
-					return NSArray.arrayWithArray((<any>data).map(serialize));
+					return NSArray.arrayWithArray(data.map((el) => serialize(el, wrapPrimitives)).filter((el) => el !== null && el !== NSNull.new()));
 				}
 
-				let node = {} as any;
-				Object.keys(data).forEach(function (key) {
-					let value = data[key];
-					node[key] = serialize(value, wrapPrimitives);
-				});
+				const node = Object.fromEntries(
+					Object.entries(data)
+						.map(([key, value]) => [key, serialize(value, wrapPrimitives)])
+						.filter(([key, value]) => value !== null && value !== NSNull.new())
+				);
+
 				return NSDictionary.dictionaryWithDictionary(node);
 			}
 


### PR DESCRIPTION
Firebase analytics' `logEvent` method fails on iOS when there's an array with null/undefined elements and when objects have null/undefined prop values. 

With this PR the null elements are filtered out of arrays and dictionaries.

This PR also fixes a slight oversight with `data.map(serialize)`, since this syntax causes the second argument to be the element index instead of `wrapPrimitives`, causing the first element not to be wrapped and all the others to be.

```ts
firebase().analytics().logEvent('eventname', [ null, undefined ]);
// Error: *** -[__NSPlaceholderArray initWithObjects:count:]: attempt to insert nil object from objects[0] Error: *** -[__NSPlaceholderArray initWithObjects:count:]: attempt to insert nil object from objects[1]

firebase().analytics().logEvent('eventname', { someProp: null, otherProp: undefined });
// Error: *** -[__NSPlaceholderDictionary initWithObjects:forKeys:count:]: attempt to insert nil object from objects[0] Error: *** -[__NSPlaceholderDictionary initWithObjects:forKeys:count:]: attempt to insert nil object from objects[0]
```

`firebase-database` might have the same issue since it declares its own version of the serialize method, but I haven't tested it.