### PR TITLE
fix(auth): ios providerData properties undefined

### DIFF
--- a/packages/firebase-auth/index.ios.ts
+++ b/packages/firebase-auth/index.ios.ts
@@ -80,27 +80,27 @@ export class UserInfo implements IUserInfo {
 	}
 
 	get uid(): string {
-		return this.native?.uid;
+		return this.native?.valueForKey("uid");
 	}
 
 	get displayName(): string {
-		return this.native?.displayName;
+		return this.native?.valueForKey("displayName");
 	}
 
 	get email(): string {
-		return this.native?.email;
+		return this.native?.valueForKey("email");
 	}
 
 	get phoneNumber(): string {
-		return this.native?.phoneNumber;
+		return this.native?.valueForKey("phoneNumber");
 	}
 
 	get photoURL(): string {
-		return this.native?.photoURL?.absoluteString;
+		return this.native?.valueForKey("photoURL")?.absoluteString;
 	}
 
 	get providerId(): string {
-		return this.native?.providerID;
+		return this.native?.valueForKey("providerID");
 	}
 
 	toJSON() {

--- a/packages/firebase-auth/typings/objc!FirebaseAuth.d.ts
+++ b/packages/firebase-auth/typings/objc!FirebaseAuth.d.ts
@@ -829,7 +829,7 @@ declare class FIRUser extends NSObject implements FIRUserInfo {
 	updatePhoneNumberCredentialCompletion(phoneNumberCredential: FIRPhoneAuthCredential, completion: (p1: NSError) => void): void;
 }
 
-interface FIRUserInfo extends NSObjectProtocol {
+interface FIRUserInfo extends NSObject {
 
 	displayName: string;
 


### PR DESCRIPTION
This PR fixes an issue where all properties of providerData values on the user were appearing as `undefined` on iOS e.g.
```
console.log(firebase.auth().currentUser.providerData[0].toJSON())
```
produces
```
{
  displayName: undefined
  email: undefined
  phoneNumber: undefined
  photoURL: undefined
  providerId: undefined
  uid: undefined
}
```