### PR TITLE
fix(messaging): readme file rename instructions do not work

### DIFF
--- a/packages/firebase-messaging-core/README.md
+++ b/packages/firebase-messaging-core/README.md
@@ -122,8 +122,8 @@ Open /platforms/ios/yourproject.**xcworkspace** (!) and go to your project's tar
 
 #### Copy the entitlements file
 
-The previous step created a the file`platforms/ios/YourAppName/(Resources/)YourAppName.entitlements`.
-Copy that file to `app/App_Resources/iOS/` (if it doesn't exist yet, otherwise merge its contents),
+The previous step created a the file `platforms/ios/YourAppName/(Resources/)YourAppName.entitlements`.
+Move and rename that file to `app/App_Resources/iOS/app.entitlements` (if it doesn't exist yet, otherwise merge its contents),
 so it's not removed when you remove and re-add the iOS platform. The relevant content for background push in that file is:
 
 ```xml

--- a/packages/firebase-messaging/README.md
+++ b/packages/firebase-messaging/README.md
@@ -508,8 +508,8 @@ Open /platforms/ios/yourproject.**xcworkspace** (!) and go to your project's tar
 
 #### Copy the entitlements file
 
-The previous step created a the file`platforms/ios/YourAppName/(Resources/)YourAppName.entitlements`.
-Copy that file to `app/App_Resources/iOS/` (if it doesn't exist yet, otherwise merge its contents),
+The previous step created a the file `platforms/ios/YourAppName/(Resources/)YourAppName.entitlements`.
+Move and rename that file to `app/App_Resources/iOS/app.entitlements` (if it doesn't exist yet, otherwise merge its contents),
 so it's not removed when you remove and re-add the iOS platform. The relevant content for background push in that file is:
 
 ```xml


### PR DESCRIPTION
When placing the file `YourAppName.entitlements in app/App_Resources/iOS/` I noticed Apple sign in and push notifications both stopped working. It appears the entitlements file should actually be called app.entitlements to be picked up by the cli. This PR corrects the advice given in the Messaging Readme.

**Tested with**
NativeScript CLI "version": "8.0.2"
Platform MacOS