### PR TITLE
Firestore improvements

### DIFF
--- a/packages/firebase-firestore/index.android.ts
+++ b/packages/firebase-firestore/index.android.ts
@@ -683,6 +683,10 @@ export class Query<T extends DocumentData = DocumentData> implements IQuery<T> {
 		return Query.fromNative(query);
 	}
 
+	isEqual(other: Query): boolean {
+		return this.native.equals(other?.native);
+	}
+
 	get native() {
 		return this._native;
 	}

--- a/packages/firebase-firestore/index.d.ts
+++ b/packages/firebase-firestore/index.d.ts
@@ -49,6 +49,8 @@ export interface IQuery<T extends DocumentData = DocumentData> {
 	startAt(fieldValues: IFieldValue[]): IQuery<T>;
 
 	where(fieldPath: keyof T | IFieldPath, opStr: WhereFilterOp, value: any): IQuery<T>;
+
+	isEqual(other: any): boolean;
 }
 
 export interface ICollectionReference<T extends DocumentData = DocumentData> {
@@ -321,6 +323,8 @@ export declare class Query<T extends DocumentData = DocumentData> implements IQu
 	startAt(fieldValues: FieldValue[]): Query;
 
 	where(fieldPath: FieldPath | keyof DocumentData, opStr: WhereFilterOp, value: any): Query;
+
+	isEqual(other: any): boolean;
 
 	readonly android: any;
 	readonly ios: any;

--- a/packages/firebase-firestore/index.ios.ts
+++ b/packages/firebase-firestore/index.ios.ts
@@ -623,6 +623,10 @@ export class Query<T extends DocumentData = DocumentData> implements IQuery<T> {
 		return Query.fromNative(query);
 	}
 
+	isEqual(other: Query): boolean {
+		return this.native.isEqual(other?.native);
+	}
+
 	get native() {
 		return this._native;
 	}

--- a/packages/firebase-firestore/platforms/ios/Podfile
+++ b/packages/firebase-firestore/platforms/ios/Podfile
@@ -1,1 +1,1 @@
-pod 'Firebase/Firestore','~>9.6'
+pod 'FirebaseFirestore', :git => 'https://github.com/invertase/firestore-ios-sdk-frameworks.git', :tag => '9.6.0'


### PR DESCRIPTION
This PR adds the `isEqual` method on the Query class and replaces the pod source to use invertase/firestore-ios-sdk-frameworks's pre-compiled .xcframeworks. This change yielded compile time improvements similar to those seen in the [project's readme](https://github.com/invertase/firestore-ios-sdk-frameworks) for my project. This is due to not having to compile several hefty frameworks (FirebaseCore, abseil, gRPC-C++, leveldb-library, nanopb) as part of the build process.

**Mac mini (2018) 6 cores:**
Before:    ~ 240s
After:     ~  45s