### PR TITLE
chore: cleanup onSnapshot implementations

### DIFF
--- a/packages/firebase-firestore/common.ts
+++ b/packages/firebase-firestore/common.ts
@@ -1,4 +1,4 @@
-import { ICollectionReference, IDocumentReference, IFieldPath, IFieldValue, IGeoPoint, ITimestamp } from '.';
+import { SnapshotListenOptions } from '.';
 
 export enum GetOptions {
 	Default = 'default',
@@ -10,4 +10,35 @@ export enum DocumentChangeType {
 	Added = 'added',
 	Removed = 'removed',
 	Modified = 'modified',
+}
+
+type Observer<SnapshotType> = { complete?: () => void; error?: (error: Error) => void; next?: (snapshot: SnapshotType) => void }
+
+export type OnSnapshotParameters<SnapshotType> =
+	| [observer: Observer<SnapshotType>]
+	| [options: SnapshotListenOptions, observer: Observer<SnapshotType>]
+	| [onNext: (snapshot: SnapshotType) => void, onError?: (error: Error) => void, onCompletion?: () => void]
+	| [options: SnapshotListenOptions, onNext: (snapshot: SnapshotType) => void, onError?: (error: Error) => void, onCompletion?: () => void]
+
+export function parseOnSnapshotArgs<SnapshotType>(args: OnSnapshotParameters<SnapshotType>) {
+	const result: SnapshotListenOptions & Observer<SnapshotType> = {
+		includeMetadataChanges: false
+	}
+	for (let i = 0; i < args.length; ++i) {
+		if (args[i] instanceof Function) {
+			// Assign whichever of next, error, complete were passed starting here
+			const fnArgsMappingOrder = ['next', 'error', 'complete'] as const
+			args.slice(i).forEach((fn, idx) => result[fnArgsMappingOrder[idx]] = fn)
+			break
+		} else if (typeof args[i] === 'object') {
+			if ('includeMetadataChanges' in args[i]) {
+				result.includeMetadataChanges = Boolean((<SnapshotListenOptions>args[i]).includeMetadataChanges)
+			} else { // Must be Observer
+				Object.assign(result, args[i])
+			}
+		} else {
+			throw new Error(`Invalid argument to onSnapshot at position ${i} of type ${typeof args[i]}: ${args[i]}`)
+		}
+	}
+	return result
 }

--- a/packages/firebase-firestore/index.android.ts
+++ b/packages/firebase-firestore/index.android.ts
@@ -1,4 +1,4 @@
-import { GetOptions, DocumentChangeType } from './common';
+import { GetOptions, DocumentChangeType, parseOnSnapshotArgs, OnSnapshotParameters } from './common';
 
 export { GetOptions, DocumentChangeType };
 
@@ -506,68 +506,23 @@ export class Query<T extends DocumentData = DocumentData> implements IQuery<T> {
 		return Query.fromNative(this.native.limitToLast(limitToLast));
 	}
 
-	onSnapshot(observer: { complete?: () => void; error?: (error: Error) => void; next?: (snapshot: QuerySnapshot) => void });
-	onSnapshot(options: SnapshotListenOptions, observer: { complete?: () => void; error?: (error: Error) => void; next?: (snapshot: QuerySnapshot) => void });
-	onSnapshot(onNext: (snapshot: QuerySnapshot) => void, onError?: (error: Error) => void, onCompletion?: () => void);
-	onSnapshot(options: SnapshotListenOptions, onNext: (snapshot: QuerySnapshot) => void, onError?: (error: Error) => void, onCompletion?: () => void);
-	onSnapshot(options: any, onNext?: any, onError?: any, onCompletion?: any): any {
-		let listener;
-		let includeMetadataChanges = com.google.firebase.firestore.MetadataChanges.EXCLUDE;
-		const argsCount = arguments.length;
-		if (typeof arguments[0] === 'object') {
-			if (typeof options?.includeMetadataChanges === 'boolean') {
-				includeMetadataChanges = com.google.firebase.firestore.MetadataChanges.INCLUDE;
-			}
-		}
+	onSnapshot(observer: { complete?: () => void; error?: (error: Error) => void; next?: (snapshot: QuerySnapshot) => void; }): () => void;
+	onSnapshot(options: SnapshotListenOptions, observer: { complete?: () => void; error?: (error: Error) => void; next?: (snapshot: QuerySnapshot) => void; }): () => void;
+	onSnapshot(onNext: (snapshot: QuerySnapshot) => void, onError?: (error: Error) => void, onCompletion?: () => void): () => void;
+	onSnapshot(options: SnapshotListenOptions, onNext: (snapshot: QuerySnapshot) => void, onError?: (error: Error) => void, onCompletion?: () => void): () => void;
+	onSnapshot(...args: OnSnapshotParameters<QuerySnapshot>): () => void {
+		const { includeMetadataChanges, ...handlers } = parseOnSnapshotArgs(args);
 
-		listener = this.native.addSnapshotListener(
-			includeMetadataChanges,
+		const listener = this.native.addSnapshotListener(
+			includeMetadataChanges
+				? com.google.firebase.firestore.MetadataChanges.INCLUDE
+				: com.google.firebase.firestore.MetadataChanges.EXCLUDE,
 			new com.google.firebase.firestore.EventListener<com.google.firebase.firestore.QuerySnapshot>({
-				onEvent(ss, error: com.google.firebase.firestore.FirebaseFirestoreException) {
-					if (argsCount > 1) {
-						if (typeof options === 'object') {
-							if (typeof onNext === 'object') {
-								if (error) {
-									onNext?.error?.(FirebaseError.fromNative(error));
-								} else {
-									onNext?.complete?.();
-									onNext?.next?.(QuerySnapshot.fromNative(ss));
-								}
-							} else {
-								if (error) {
-									onError?.(FirebaseError.fromNative(error));
-								} else {
-									// onError -> onCompletion
-									onCompletion?.();
-									// options -> onNext
-									onNext?.(QuerySnapshot.fromNative(ss));
-								}
-							}
-						} else {
-							if (error) {
-								//onError -> onNext
-								onNext?.(FirebaseError.fromNative(error));
-							} else {
-								// onCompletion ->
-								onError?.();
-								// options -> onNext
-								options?.(QuerySnapshot.fromNative(ss));
-							}
-						}
+				onEvent(querySnapshot, error: com.google.firebase.firestore.FirebaseFirestoreException) {
+					if (error) {
+						handlers.error?.(FirebaseError.fromNative(error));
 					} else {
-						if (typeof arguments[1] === 'function') {
-							// onNext -> options
-							if (!error) {
-								options?.(QuerySnapshot.fromNative(ss));
-							}
-						} else {
-							if (error) {
-								options?.error?.(FirebaseError.fromNative(error));
-							} else {
-								options?.complete?.();
-								options?.next?.(QuerySnapshot.fromNative(ss));
-							}
-						}
+						handlers.next?.(QuerySnapshot.fromNative(querySnapshot));
 					}
 				},
 			})
@@ -948,68 +903,23 @@ export class DocumentReference<T extends DocumentData = DocumentData> implements
 		});
 	}
 
-	onSnapshot(observer: { complete?: () => void; error?: (error: Error) => void; next?: (snapshot: DocumentSnapshot<T>) => void });
-	onSnapshot(options: SnapshotListenOptions, observer: { complete?: () => void; error?: (error: Error) => void; next?: (snapshot: DocumentSnapshot<T>) => void });
-	onSnapshot(onNext: (snapshot: DocumentSnapshot<T>) => void, onError?: (error: Error) => void, onCompletion?: () => void);
-	onSnapshot(options: SnapshotListenOptions, onNext: (snapshot: DocumentSnapshot<T>) => void, onError?: (error: Error) => void, onCompletion?: () => void);
-	onSnapshot(options: any, onNext?: any, onError?: any, onCompletion?: any) {
-		let listener;
-		let includeMetadataChanges = com.google.firebase.firestore.MetadataChanges.EXCLUDE;
-		const argsCount = arguments.length;
-		if (typeof arguments[0] === 'object') {
-			if (typeof options?.includeMetadataChanges === 'boolean') {
-				includeMetadataChanges = com.google.firebase.firestore.MetadataChanges.INCLUDE;
-			}
-		}
+	onSnapshot(observer: { complete?: () => void; error?: (error: Error) => void; next?: (snapshot: DocumentSnapshot<T>) => void; }): () => void;
+	onSnapshot(options: SnapshotListenOptions, observer: { complete?: () => void; error?: (error: Error) => void; next?: (snapshot: DocumentSnapshot<T>) => void; }): () => void;
+	onSnapshot(onNext: (snapshot: DocumentSnapshot<T>) => void, onError?: (error: Error) => void, onCompletion?: () => void): () => void;
+	onSnapshot(options: SnapshotListenOptions, onNext: (snapshot: DocumentSnapshot<T>) => void, onError?: (error: Error) => void, onCompletion?: () => void): () => void;
+	onSnapshot(...args: OnSnapshotParameters<DocumentSnapshot<T>>): () => void {
+		const { includeMetadataChanges, ...handlers } = parseOnSnapshotArgs(args);
 
-		listener = this.native.addSnapshotListener(
-			includeMetadataChanges,
+		const listener = this.native.addSnapshotListener(
+			includeMetadataChanges
+				? com.google.firebase.firestore.MetadataChanges.INCLUDE
+				: com.google.firebase.firestore.MetadataChanges.EXCLUDE,
 			new com.google.firebase.firestore.EventListener<com.google.firebase.firestore.DocumentSnapshot>({
-				onEvent(ss, error: com.google.firebase.firestore.FirebaseFirestoreException) {
-					if (argsCount > 1) {
-						if (typeof options === 'object') {
-							if (typeof onNext === 'object') {
-								if (error) {
-									onNext?.error?.(FirebaseError.fromNative(error));
-								} else {
-									onNext?.complete?.();
-									onNext?.next?.(DocumentSnapshot.fromNative(ss));
-								}
-							} else {
-								if (error) {
-									onError?.(FirebaseError.fromNative(error));
-								} else {
-									// onError -> onCompletion
-									onCompletion?.();
-									// options -> onNext
-									onNext?.(DocumentSnapshot.fromNative(ss));
-								}
-							}
-						} else {
-							if (error) {
-								//onError -> onNext
-								onNext?.(FirebaseError.fromNative(error));
-							} else {
-								// onCompletion ->
-								onError?.();
-								// options -> onNext
-								options?.(DocumentSnapshot.fromNative(ss));
-							}
-						}
+				onEvent(docSnapshot, error: com.google.firebase.firestore.FirebaseFirestoreException) {
+					if (error) {
+						handlers.error?.(FirebaseError.fromNative(error));
 					} else {
-						if (typeof arguments[1] === 'function') {
-							// onNext -> options
-							if (!error) {
-								options?.(DocumentSnapshot.fromNative(ss));
-							}
-						} else {
-							if (error) {
-								options?.error?.(FirebaseError.fromNative(error));
-							} else {
-								options?.complete?.();
-								options?.next?.(DocumentSnapshot.fromNative(ss));
-							}
-						}
+						handlers.next?.(DocumentSnapshot.fromNative(docSnapshot));
 					}
 				},
 			})

--- a/packages/firebase-firestore/index.d.ts
+++ b/packages/firebase-firestore/index.d.ts
@@ -23,7 +23,8 @@ export interface IQuery<T extends DocumentData = DocumentData> {
 
 	limitToLast(limitToLast: number): IQuery<T>;
 
-	onSnapshot(observer: { complete?: () => void; error?: (error: Error) => void; next?: (snapshot: IQuerySnapshot<T>) => void });
+	/** NOTE: Although an onCompletion callback can be provided, it will never be called because the snapshot stream is never-ending. */
+	onSnapshot(observer: { complete?: () => void; error?: (error: Error) => void; next?: (snapshot: IQuerySnapshot<T>) => void }): () => void;
 
 	onSnapshot(
 		options: SnapshotListenOptions,
@@ -32,11 +33,11 @@ export interface IQuery<T extends DocumentData = DocumentData> {
 			error?: (error: Error) => void;
 			next?: (snapshot: IQuerySnapshot<T>) => void;
 		}
-	);
+	): () => void;
 
-	onSnapshot(onNext: (snapshot: IQuerySnapshot<T>) => void, onError?: (error: Error) => void, onCompletion?: () => void);
+	onSnapshot(onNext: (snapshot: IQuerySnapshot<T>) => void, onError?: (error: Error) => void, onCompletion?: () => void): () => void;
 
-	onSnapshot(options: SnapshotListenOptions, onNext: (snapshot: IQuerySnapshot<T>) => void, onError?: (error: Error) => void, onCompletion?: () => void);
+	onSnapshot(options: SnapshotListenOptions, onNext: (snapshot: IQuerySnapshot<T>) => void, onError?: (error: Error) => void, onCompletion?: () => void): () => void;
 
 	orderBy(fieldPath: keyof T | IFieldPath, directionStr?: 'asc' | 'desc'): IQuery<T>;
 
@@ -106,7 +107,8 @@ export interface IDocumentReference<T extends DocumentData = DocumentData> {
 
 	get(options?: GetOptions): Promise<IDocumentSnapshot<T>>;
 
-	onSnapshot(observer: { complete?: () => void; error?: (error: Error) => void; next?: (snapshot: IDocumentSnapshot<T>) => void });
+	/** NOTE: Although an onCompletion callback can be provided, it will never be called because the snapshot stream is never-ending. */
+	onSnapshot(observer: { complete?: () => void; error?: (error: Error) => void; next?: (snapshot: IDocumentSnapshot<T>) => void }): () => void;
 
 	onSnapshot(
 		options: SnapshotListenOptions,
@@ -115,11 +117,11 @@ export interface IDocumentReference<T extends DocumentData = DocumentData> {
 			error?: (error: Error) => void;
 			next?: (snapshot: IDocumentSnapshot<T>) => void;
 		}
-	);
+	): () => void;
 
-	onSnapshot(onNext: (snapshot: IDocumentSnapshot<T>) => void, onError?: (error: Error) => void, onCompletion?: () => void);
+	onSnapshot(onNext: (snapshot: IDocumentSnapshot<T>) => void, onError?: (error: Error) => void, onCompletion?: () => void): () => void;
 
-	onSnapshot(options: SnapshotListenOptions, onNext: (snapshot: IDocumentSnapshot<T>) => void, onError?: (error: Error) => void, onCompletion?: () => void);
+	onSnapshot(options: SnapshotListenOptions, onNext: (snapshot: IDocumentSnapshot<T>) => void, onError?: (error: Error) => void, onCompletion?: () => void): () => void;
 
 	set(data: T, options?: SetOptions): Promise<void>;
 
@@ -307,10 +309,10 @@ export declare class Query<T extends DocumentData = DocumentData> implements IQu
 
 	limitToLast(limitToLast: number): Query;
 
-	onSnapshot(observer: { complete?: () => void; error?: (error: Error) => void; next?: (snapshot: QuerySnapshot) => void });
-	onSnapshot(options: SnapshotListenOptions, observer: { complete?: () => void; error?: (error: Error) => void; next?: (snapshot: QuerySnapshot) => void });
-	onSnapshot(onNext: (snapshot: QuerySnapshot) => void, onError?: (error: Error) => void, onCompletion?: () => void);
-	onSnapshot(options: SnapshotListenOptions, onNext: (snapshot: QuerySnapshot) => void, onError?: (error: Error) => void, onCompletion?: () => void);
+	onSnapshot(observer: { complete?: () => void; error?: (error: Error) => void; next?: (snapshot: QuerySnapshot) => void }): () => void;
+	onSnapshot(options: SnapshotListenOptions, observer: { complete?: () => void; error?: (error: Error) => void; next?: (snapshot: QuerySnapshot) => void }): () => void;
+	onSnapshot(onNext: (snapshot: QuerySnapshot) => void, onError?: (error: Error) => void, onCompletion?: () => void): () => void;
+	onSnapshot(options: SnapshotListenOptions, onNext: (snapshot: QuerySnapshot) => void, onError?: (error: Error) => void, onCompletion?: () => void): () => void;
 
 	orderBy(fieldPath: keyof DocumentData | FieldPath, directionStr: 'asc' | 'desc' = 'asc'): Query;
 
@@ -388,10 +390,10 @@ export declare class DocumentReference<T extends DocumentData = DocumentData> im
 
 	get(options?: GetOptions): Promise<DocumentSnapshot<T>>;
 
-	onSnapshot(observer: { complete?: () => void; error?: (error: Error) => void; next?: (snapshot: DocumentSnapshot<T>) => void });
-	onSnapshot(options: SnapshotListenOptions, observer: { complete?: () => void; error?: (error: Error) => void; next?: (snapshot: DocumentSnapshot<T>) => void });
-	onSnapshot(onNext: (snapshot: DocumentSnapshot<T>) => void, onError?: (error: Error) => void, onCompletion?: () => void);
-	onSnapshot(options: SnapshotListenOptions, onNext: (snapshot: DocumentSnapshot<T>) => void, onError?: (error: Error) => void, onCompletion?: () => void);
+	onSnapshot(observer: { complete?: () => void; error?: (error: Error) => void; next?: (snapshot: DocumentSnapshot<T>) => void }): () => void;
+	onSnapshot(options: SnapshotListenOptions, observer: { complete?: () => void; error?: (error: Error) => void; next?: (snapshot: DocumentSnapshot<T>) => void }): () => void;
+	onSnapshot(onNext: (snapshot: DocumentSnapshot<T>) => void, onError?: (error: Error) => void, onCompletion?: () => void): () => void;
+	onSnapshot(options: SnapshotListenOptions, onNext: (snapshot: DocumentSnapshot<T>) => void, onError?: (error: Error) => void, onCompletion?: () => void): () => void;
 
 	set(data: T, options?: SetOptions): Promise<void>;
 


### PR DESCRIPTION
While I had mainly written this refactor to address bugs that were probably addressed in ba384c21ff6384e9db365ed5c21281b1da9ec5ff and c74f67a90e68fd69fbc823016ad9c6305bbc687f, I still believe this is worth submitting as the current onSnapshot handler implementations are very difficult to understand due to parameter names and overloads. This refactor aims to address the issue of parsing the parameters (with full type checking) centrally in a single `parseOnSnapshotArgs` helper, after which we can implement the actual handling logic in a way that looks much more intuitive in the individual onSnapshot methods.