### PR TITLE
fix(firestore)(android): arrayUnion always appends null to array

### DIFF
--- a/packages/firebase-firestore/index.android.ts
+++ b/packages/firebase-firestore/index.android.ts
@@ -1118,11 +1118,11 @@ export class FieldValue implements IFieldValue {
 	}
 
 	static arrayRemove(elements: any[]): FieldValue {
-		return FieldValue.fromNative(com.google.firebase.firestore.FieldValue.arrayRemove(elements.map((element) => element?.native || element)));
+		return FieldValue.fromNative(com.google.firebase.firestore.FieldValue.arrayRemove(elements.map((element) => element?.native || serializeItems(element))));
 	}
 
 	static arrayUnion(elements: any[]): FieldValue {
-		return FieldValue.fromNative(com.google.firebase.firestore.FieldValue.arrayUnion(elements.map((element) => element?.native || element)));
+		return FieldValue.fromNative(com.google.firebase.firestore.FieldValue.arrayUnion(elements.map((element) => element?.native || serializeItems(element))));
 	}
 
 	static delete(): FieldValue {


### PR DESCRIPTION
Fixes an issue where using arrayUnion to append new items to an array field on android results in `null` being appended regardless of what data is passed into `elements`