### PR TITLE
fix(messaging): Activity registerForActivityResult is not a function

### DIFF
--- a/packages/firebase-messaging-core/index.android.ts
+++ b/packages/firebase-messaging-core/index.android.ts
@@ -58,18 +58,23 @@ let _permissionQueue: { resolve: Function; reject: Function }[] = [];
 
 function register(args: any) {
 	if (!lastActivity) {
-		lastActivity = new WeakRef(args.activity);
-		requestPermissionLauncher = args.activity.registerForActivityResult(
-			new androidx.activity.result.contract.ActivityResultContracts.RequestPermission(),
-			new androidx.activity.result.ActivityResultCallback({
-				onActivityResult(isGranted: boolean) {
-					_permissionQueue.forEach((callback) => {
-						callback.resolve(isGranted ? 0 : 1);
-					});
-					_permissionQueue.splice(0);
-				},
-			})
-		);
+    // Some activities do not implement activity result API
+    if (args.activity.registerForActivityResult) {
+      lastActivity = new WeakRef(args.activity);
+      requestPermissionLauncher = args.activity.registerForActivityResult(
+        new androidx.activity.result.contract.ActivityResultContracts.RequestPermission(),
+        new androidx.activity.result.ActivityResultCallback({
+          onActivityResult(isGranted: boolean) {
+            _permissionQueue.forEach((callback) => {
+              callback.resolve(isGranted ? 0 : 1);
+            });
+            _permissionQueue.splice(0);
+          },
+        })
+      );
+    } else {
+      Application.android.once('activityCreated', register);
+    }
 	}
 }
 


### PR DESCRIPTION
This is a fix for what I described in issue #152 . It seems we call `register()` when activities get created so we have to take precautions for activities who do not support activity result API.

Still, I wonder if we should just ignore those activities or treat them differently.

Fixes #152 https://github.com/NativeScript/payments/issues/19