### PR TITLE
fix(dynamic-links): export ShortLinkType as an object

### DIFF
--- a/packages/firebase-dynamic-links/index.android.ts
+++ b/packages/firebase-dynamic-links/index.android.ts
@@ -15,6 +15,8 @@ Object.defineProperty(fb, 'dynamicLinks', {
 	writable: false,
 });
 
+export { ShortLinkType } from './common';
+
 export class DynamicLinkAnalyticsParameters implements IDynamicLinkAnalyticsParameters {
 	_builder: com.google.firebase.dynamiclinks.DynamicLink.GoogleAnalyticsParameters.Builder;
 	_native: com.google.firebase.dynamiclinks.DynamicLink.GoogleAnalyticsParameters;

--- a/packages/firebase-dynamic-links/index.d.ts
+++ b/packages/firebase-dynamic-links/index.d.ts
@@ -1,6 +1,8 @@
 import { FirebaseApp } from '@nativescript/firebase-core';
 import { ShortLinkType, IDynamicLink } from './common';
 
+export { ShortLinkType };
+
 export class DynamicLinkAnalyticsParameters implements IDynamicLinkAnalyticsParameters {
 	readonly native;
 	readonly ios;

--- a/packages/firebase-dynamic-links/index.d.ts
+++ b/packages/firebase-dynamic-links/index.d.ts
@@ -1,8 +1,6 @@
 import { FirebaseApp } from '@nativescript/firebase-core';
 import { ShortLinkType, IDynamicLink } from './common';
 
-export { ShortLinkType };
-
 export class DynamicLinkAnalyticsParameters implements IDynamicLinkAnalyticsParameters {
 	readonly native;
 	readonly ios;

--- a/packages/firebase-dynamic-links/index.ios.ts
+++ b/packages/firebase-dynamic-links/index.ios.ts
@@ -16,6 +16,8 @@ Object.defineProperty(fb, 'dynamicLinks', {
 
 declare const FIRApp, TNSFirebaseDynamicLinksAppDelegate;
 
+export { ShortLinkType } from './common';
+
 export class DynamicLinkAnalyticsParameters implements IDynamicLinkAnalyticsParameters {
 	_native: FIRDynamicLinkGoogleAnalyticsParameters;
 


### PR DESCRIPTION
`ShortLinkType` is exported only as a type in the `index.d.ts` file, but since it is an enum it should be exported as a value too, otherwise get errors like: `Cannot read property 'UNGUESSABLE' of undefined`