### PR TITLE
fix(dynamic-links): ios parameters builder assigned to wrong variable

### DIFF
--- a/packages/firebase-dynamic-links/.eslintrc.json
+++ b/packages/firebase-dynamic-links/.eslintrc.json
@@ -1,6 +1,6 @@
 {
 	"extends": ["../../.eslintrc.json"],
-	"ignorePatterns": ["!**/*", "node_modules/**/*"],
+	"ignorePatterns": ["!**/*", "node_modules/**/*", "typings/**/*"],
 	"overrides": [
 		{
 			"files": ["*.ts", "*.tsx", "*.js", "*.jsx"],

--- a/packages/firebase-dynamic-links/index.android.ts
+++ b/packages/firebase-dynamic-links/index.android.ts
@@ -140,7 +140,7 @@ export class DynamicLinkIOSParameters implements IDynamicLinkIOSParameters {
 	_bundleId: string;
 	constructor(bundleId?: string) {
 		this._bundleId = bundleId;
-		this._native = new com.google.firebase.dynamiclinks.DynamicLink.IosParameters.Builder(bundleId);
+		this._builder = new com.google.firebase.dynamiclinks.DynamicLink.IosParameters.Builder(bundleId);
 	}
 
 	static fromNative(link: com.google.firebase.dynamiclinks.DynamicLink.IosParameters) {


### PR DESCRIPTION
Fix the variable assignment for `DynamicLinkIOSParameters` on Android, it's currently assigning the builder to the native parameters object. This incorrect assignment causes the following error when trying to generate short links:

```
JNI DETECTED ERROR IN APPLICATION: bad arguments passed to com.google.firebase.dynamiclinks.DynamicLink$Builder com.google.firebase.dynamiclinks.DynamicLink$Builder.setIosParameters(com.google.firebase.dynamiclinks.DynamicLink$IosParameters) (see above for details)
```