### PR TITLE
fix(dynamic-links): build link before generating long link

### DIFF
--- a/packages/firebase-dynamic-links/index.android.ts
+++ b/packages/firebase-dynamic-links/index.android.ts
@@ -491,7 +491,7 @@ export class DynamicLinks implements IDynamicLinks {
 					})
 				);
 			} else {
-				resolve(link.native.buildDynamicLink().getUri().toString());
+				resolve(link._build().buildDynamicLink().getUri().toString());
 			}
 		});
 	}


### PR DESCRIPTION
`_build()` was only called for short links, this caused long links to not respect the values for `analytics`, `android`, `ios`, `itunes`, `navigation`, and `social` props.