### PR TITLE
fix(firebase-analytics): consistent handling of Podfile variable $NSFirebaseAnalyticsWithoutAdIdSupport

### DIFF
--- a/packages/firebase-analytics/hooks/before-checkForChanges.ts
+++ b/packages/firebase-analytics/hooks/before-checkForChanges.ts
@@ -1,23 +1,37 @@
-const fs = require('fs');
-const path = require('path');
+import * as fs from 'fs';
+import * as path from 'path';
 
 export = function ($logger, $projectData, hookArgs) {
 	const platformName = ((hookArgs.prepareData && hookArgs.prepareData.platform) || (hookArgs.platformData && hookArgs.platformData.normalizedPlatformName) || '').toLowerCase();
 
 	if (platformName === 'ios') {
-		const rootPath = $projectData.projectDir;
-
-		const Podfile = path.join(rootPath, 'platforms', 'ios', 'Podfile');
 		const ResourcePodfile = $projectData.podfilePath;
+		const PluginPodfile = path.join(__dirname, '..', 'platforms', 'ios', 'Podfile');
 
-		if (fs.existsSync(Podfile) && fs.existsSync(ResourcePodfile)) {
-			const podData = fs.readFileSync(Podfile, 'utf8') || '';
+		if (fs.existsSync(PluginPodfile) && fs.existsSync(ResourcePodfile)) {
+			const pluginPodData = fs.readFileSync(PluginPodfile, 'utf8') || '';
 			const resourcePodData = fs.readFileSync(ResourcePodfile, 'utf8');
 
-			// set variable early in the Podfile
+			// set variable in our Podfile to ensure it's picked up correctly
+			if (pluginPodData) {
+				const placeholderRegex = /^(\s*)(.*?)### PLACEHOLDER_FOR_HOOK: \$NSFirebaseAnalyticsWithoutAdIdSupport$/m;
+				const enabledRegex = /^(\s*)\$NSFirebaseAnalyticsWithoutAdIdSupport=true\b/m;
+				const isEnabled = enabledRegex.test(resourcePodData);
 
-			if (podData && resourcePodData && resourcePodData.indexOf('$NSFirebaseAnalyticsWithoutAdIdSupport=true') > -1 && podData.indexOf('$NSFirebaseAnalyticsWithoutAdIdSupport=true') !== 0) {
-				fs.writeFileSync(Podfile, '$NSFirebaseAnalyticsWithoutAdIdSupport=true \n' + podData);
+				const pluginMatch = pluginPodData.match(placeholderRegex);
+				if (pluginMatch) {
+					// this will always be:
+					// `   ### PLACEHOLDER_FOR_HOOK: $NSFirebaseAnalyticsWithoutAdIdSupport`
+					// or `   $NSFirebaseAnalyticsWithoutAdIdSupport=true ### PLACEHOLDER_FOR_HOOK: $NSFirebaseAnalyticsWithoutAdIdSupport`
+					// indentation is always preserved, and an extra space is added after "true"
+					const replacement = isEnabled ? '$NSFirebaseAnalyticsWithoutAdIdSupport=true ' : '';
+					const replacementLine = `${pluginMatch[1]}${replacement}### PLACEHOLDER_FOR_HOOK: $NSFirebaseAnalyticsWithoutAdIdSupport`;
+					if (replacementLine !== pluginMatch[0]) {
+						fs.writeFileSync(PluginPodfile, pluginPodData.replace(placeholderRegex, replacementLine));
+					}
+				} else {
+					$logger.warn(`Could not find NSFirebaseAnalyticsWithoutAdIdSupport placeholder in ${PluginPodfile}`);
+				}
 			}
 		}
 	}

--- a/packages/firebase-analytics/platforms/ios/Podfile
+++ b/packages/firebase-analytics/platforms/ios/Podfile
@@ -1,5 +1,6 @@
 platform :ios, '10.0'
   # Firebase dependencies
+  ### PLACEHOLDER_FOR_HOOK: $NSFirebaseAnalyticsWithoutAdIdSupport
   if defined?($NSFirebaseAnalyticsWithoutAdIdSupport)
     Pod::UI.puts "Using Firebase/AnalyticsWithoutAdIdSupport pod in place of default Firebase/Analytics"
 


### PR DESCRIPTION
Some context:

Before we would find the platforms/ios/Podfile and add $NSFirebaseAnalyticsWithoutAdIdSupport to the top. Turns out that the file is not always available on before-checkForChanges and it's only available consistently in after-prepare, which is already too late (pods already installed). As a result, the first build would not have the option, and from the second build onwards it would.

So instead of adding another hook to the cli, I simply modify the Podfile in node_modules. The code is resilient enough to always update the Podfile if the desired result is different from the current state (if `$NSFirebaseAnalyticsWithoutAdIdSupport=true` in the user Podfile, it will add to the plugin Podfile if missing. If `NSFirebaseAnalyticsWithoutAdIdSupport=true` is present in the plugin Podfile but not on the user Podfile then we always remove it).

It also now supports comments (`#$NSFirebaseAnalyticsWithoutAdIdSupport=true` will not add to the podfile).

Ideally we should fix the CLI so we could have a `BeforePluginsPodfile` (or something. Similar to `before-plugins.gradle` on android)


Fixes https://github.com/NativeScript/firebase/issues/128