### PR TITLE
feat(dynamic-links): forward errors to application

### DIFF
--- a/packages/firebase-dynamic-links/common.ts
+++ b/packages/firebase-dynamic-links/common.ts
@@ -1,4 +1,4 @@
-import { FirebaseApp } from '@nativescript/firebase-core';
+import { FirebaseApp, FirebaseError } from '@nativescript/firebase-core';
 
 export enum ShortLinkType {
 	DEFAULT = 'default',
@@ -67,11 +67,13 @@ export interface IDynamicLink {
 	utmParameters: Record<string, string>;
 }
 
+export type OnLinkListener = (link: IDynamicLink | null, error: FirebaseError | null) => void;
+
 export interface IDynamicLinks {
 	app: FirebaseApp;
 	createLink(link: string, domainUriPrefix: string): IDynamicLinkParameters;
 	createShortLink(link: string, domainUriPrefix: string, shortLinkType?: ShortLinkType): IDynamicLinkParameters;
 	buildLink(link: IDynamicLinkParameters): Promise<string>;
-	onLink(listener: (link: IDynamicLink) => void);
+	onLink(listener: OnLinkListener);
 	resolveLink(link: string): Promise<IDynamicLink>;
 }

--- a/packages/firebase-dynamic-links/index.d.ts
+++ b/packages/firebase-dynamic-links/index.d.ts
@@ -1,4 +1,4 @@
-import { FirebaseApp } from '@nativescript/firebase-core';
+import { FirebaseApp, FirebaseError } from '@nativescript/firebase-core';
 import { ShortLinkType, IDynamicLink } from './common';
 
 export { ShortLinkType };
@@ -93,6 +93,8 @@ export declare class DynamicLink implements IDynamicLink {
 	readonly android;
 }
 
+export type OnLinkListener = (link: DynamicLink | null, error: FirebaseError | null) => void;
+
 export declare class DynamicLinks implements IDynamicLinks {
 	createLink(link: string, domainUriPrefix: string): DynamicLinkParameters;
 
@@ -100,7 +102,7 @@ export declare class DynamicLinks implements IDynamicLinks {
 
 	buildLink(link: DynamicLinkParameters): Promise<string>;
 
-	onLink(listener: (link: DynamicLink) => void);
+	onLink(listener: OnLinkListener): void;
 
 	resolveLink(link: string): Promise<DynamicLink>;
 

--- a/packages/firebase-dynamic-links/index.ios.ts
+++ b/packages/firebase-dynamic-links/index.ios.ts
@@ -1,5 +1,5 @@
 import { deserialize, firebase, FirebaseApp, FirebaseError } from '@nativescript/firebase-core';
-import { IDynamicLink, IDynamicLinkAnalyticsParameters, IDynamicLinkAndroidParameters, IDynamicLinkIOSParameters, IDynamicLinkITunesParameters, IDynamicLinkNavigationParameters, IDynamicLinkParameters, IDynamicLinks, IDynamicLinkSocialParameters, ShortLinkType } from './common';
+import { IDynamicLink, IDynamicLinkAnalyticsParameters, IDynamicLinkAndroidParameters, IDynamicLinkIOSParameters, IDynamicLinkITunesParameters, IDynamicLinkNavigationParameters, IDynamicLinkParameters, IDynamicLinks, IDynamicLinkSocialParameters, OnLinkListener, ShortLinkType } from './common';
 
 let defaultDynamicLinks: DynamicLinks;
 const fb = firebase();
@@ -457,7 +457,7 @@ export class DynamicLink implements IDynamicLink {
 export class DynamicLinks implements IDynamicLinks {
 	_native: FIRDynamicLinks;
 	_app: FirebaseApp;
-	static _onLink: (link: DynamicLink) => void;
+	static _onLink: OnLinkListener;
 	constructor() {
 		if (defaultDynamicLinks) {
 			return defaultDynamicLinks;
@@ -504,11 +504,11 @@ export class DynamicLinks implements IDynamicLinks {
 		}
 	}
 
-	onLink(listener: (link: DynamicLink) => void) {
+	onLink(listener: OnLinkListener) {
 		DynamicLinks._onLink = listener;
 		if (listener) {
-			TNSFirebaseDynamicLinksAppDelegate.onLinkCallback = (link) => {
-				listener(DynamicLink.fromNative(link));
+			TNSFirebaseDynamicLinksAppDelegate.onLinkCallback = (link, error) => {
+				listener(DynamicLink.fromNative(link), error && FirebaseError.fromNative(error));
 			};
 		} else {
 			TNSFirebaseDynamicLinksAppDelegate.onLinkCallback = null;

--- a/packages/firebase-dynamic-links/platforms/ios/src/TNSFirebaseDynamicLinksAppDelegate.swift
+++ b/packages/firebase-dynamic-links/platforms/ios/src/TNSFirebaseDynamicLinksAppDelegate.swift
@@ -10,7 +10,7 @@ public class TNSFirebaseDynamicLinksAppDelegate: UIResponder , UIApplicationDele
     
     private static var _sharedInstance: TNSFirebaseDynamicLinksAppDelegate?  = nil
     
-    @objc public static var onLinkCallback: ((DynamicLink) -> Void)? = nil
+    @objc public static var onLinkCallback: ((DynamicLink?, Error?) -> Void)? = nil
     
     @objc public static var sharedInstance: TNSFirebaseDynamicLinksAppDelegate {
         get {
@@ -30,22 +30,14 @@ public class TNSFirebaseDynamicLinksAppDelegate: UIResponder , UIApplicationDele
         
         if (dynamicLink == nil) {
            DynamicLinks.dynamicLinks().dynamicLink(fromUniversalLink: url, completion: { dynamicLink, error in
-                if (dynamicLink?.url != nil) {
-                    DispatchQueue.main.async {
-                        TNSFirebaseDynamicLinksAppDelegate.onLinkCallback?(dynamicLink!)
-                    }
+                DispatchQueue.main.async {
+                    TNSFirebaseDynamicLinksAppDelegate.onLinkCallback?(dynamicLink, error)
                 }
             })
             return false
         }
         
-        if (dynamicLink == nil) {
-            return false
-        }
-        
-        if (dynamicLink?.url != nil) {
-            TNSFirebaseDynamicLinksAppDelegate.onLinkCallback?(dynamicLink!)
-        }
+        TNSFirebaseDynamicLinksAppDelegate.onLinkCallback?(dynamicLink, nil)
         
         return false
     }
@@ -63,23 +55,16 @@ public class TNSFirebaseDynamicLinksAppDelegate: UIResponder , UIApplicationDele
         
         if(userActivity.webpageURL != nil){
             DynamicLinks.dynamicLinks().handleUniversalLink(userActivity.webpageURL!) { dynamicLink, error in
-                if(error == nil && dynamicLink?.url != nil){
-                    TNSFirebaseDynamicLinksAppDelegate.onLinkCallback?(dynamicLink!)
-                }
-                
-                
                 if(error != nil && !retried && (error as? NSError)?.domain == NSPOSIXErrorDomain && (error as? NSError)?.code == 53){
                     retried = true
                     DynamicLinks.dynamicLinks().handleUniversalLink(userActivity.webpageURL!) { dynamicLink, error in
-                        
-                        if(error == nil && dynamicLink?.url != nil){
-                            TNSFirebaseDynamicLinksAppDelegate.onLinkCallback?(dynamicLink!)
-                        }
+                        TNSFirebaseDynamicLinksAppDelegate.onLinkCallback?(dynamicLink, error)
                         if(error != nil && error?.localizedDescription != nil){
                             NSLog("%@", "CONSOLE LOG: ", error!.localizedDescription)
                         }
-                        
                     }
+                } else {
+                    TNSFirebaseDynamicLinksAppDelegate.onLinkCallback?(dynamicLink, error)
                 }
             }
         }


### PR DESCRIPTION
This PR adds an optional parameter to the `onLink` handler that indicates the error that occurred while fetching the target of a short dynamic link.

There are two reasons for this change:
- This makes both iOS and Android behave the same for unknown links. Right now the Android handler emits null for unknown links, while iOS simply ignores them.
- The error is useful for applications that need to show some sort of user message or dispatch an event upon malformed or unknown dynamic links.

**BREAKING CHANGE:** This change will call the dynamic link handler with null values on iOS. For Android, it'll be the same as before since the error param is optional.