### PR TITLE
fix(dynamic-links): IllegalArgumentException on resolveLink

### DIFF
--- a/packages/firebase-dynamic-links/src-native/android/dynamic_links/src/main/java/org/nativescript/firebase/dynamic_links/FirebaseDynamicLinks.kt
+++ b/packages/firebase-dynamic-links/src-native/android/dynamic_links/src/main/java/org/nativescript/firebase/dynamic_links/FirebaseDynamicLinks.kt
@@ -120,7 +120,6 @@ class FirebaseDynamicLinks : Application.ActivityLifecycleCallbacks {
       url: String,
       callback: Callback<PendingDynamicLinkData>
     ) {
-      links.createDynamicLink().buildShortDynamicLink()
       try {
         links.getDynamicLink(Uri.parse(url))
           .addOnCompleteListener(executors) {


### PR DESCRIPTION
This PR fixes the following error when calling `resolveLink` on android:
```
Error: java.lang.IllegalArgumentException: FDL domain is missing. Set with setDomainUriPrefix() or setDynamicLinkDomain().
```

I imagine that the buildShortDynamicLink is either a leftover from older code or was pasted by accident in that method implementation.