### PR TITLE
fix: work with latest cli

### DIFF
--- a/packages/firebase-core/platforms/android/include.gradle
+++ b/packages/firebase-core/platforms/android/include.gradle
@@ -1,4 +1,6 @@
-apply plugin: 'com.google.gms.google-services'
+if (!project.hasProperty("tempBuild")) {
+	apply plugin: 'com.google.gms.google-services'
+}
 dependencies {
     def computeKotlinVersion = { -> project.hasProperty("kotlinVersion") ? kotlinVersion : "1.4.32" }
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$computeKotlinVersion"


### PR DESCRIPTION
this ensure we dont apply for tempPLugin build which would require a google-services.json. This is not needed for the tempPlugin build