### PR TITLE
Update README.md highlighting dependency on sibling plugins

### DIFF
--- a/packages/firebase-core/README.md
+++ b/packages/firebase-core/README.md
@@ -48,6 +48,8 @@ To set up Firebase for iOS, see [Add Firebase to your Apple project](https://fir
 
 ## Use @nativescript/firebase-core
 
+ 🚨 Plugin requires both `@nativescript/firebase-core` and any other `@nativescript/firebase-*` plugin to successfully initialize.
+
 ### Instantiate Firebase and initialize a default app
 
 Import the `firebase` function and call it to create a NativeScript Firebase instance. Next, call the `initializeApp` method on the Firebase instance to instantiate the native [FirebaseApp](https://firebase.google.com/docs/reference/android/com/google/firebase/FirebaseApp).


### PR DESCRIPTION
I don't believe it is currently communicated clearly that `@nativescript/firebase-core` cannot initialize successfully on it's own.

@nativescript/firebase-core initialization code
```
    const defaultApp = firebase().initializeApp().then(() => {
        console.warn('🔥 Firebase initialized');
      }).catch(error => {
        console.error('🔥 Firebase initialization error: ', error)
      });
```

fails on android with: `Error: Cannot read properties of undefined (reading 'FirebaseApp')`
fails on iOS with: `Error: FIRApp is not defined`




Installing plugin `@nativescript/firebase-messaging`, I assume any other would work too, makes the initialization a success
