### PR TITLE
fix(analytics): typings

### DIFF
--- a/packages/firebase-analytics/index.d.ts
+++ b/packages/firebase-analytics/index.d.ts
@@ -32,5 +32,5 @@ declare module '@nativescript/firebase-core' {
 }
 
 export interface FirebaseAnalytics {
-	static analytics(): Analytics;
+	analytics(): Analytics;
 }


### PR DESCRIPTION
An interface (or type) cannot have a member with a "static" modifier.