### PR TITLE
Update include.gradle with Play Integrity

### DIFF
--- a/packages/firebase-app-check/platforms/android/include.gradle
+++ b/packages/firebase-app-check/platforms/android/include.gradle
@@ -1,6 +1,6 @@
 dependencies {
-    def computeFirebaseBomVersion = { -> project.hasProperty("firebaseBomVersion") ? firebaseBomVersion : "31.2.3" }
+    def computeFirebaseBomVersion = { -> project.hasProperty("firebaseBomVersion") ? firebaseBomVersion : "32.2.2" }
     implementation platform("com.google.firebase:firebase-bom:${computeFirebaseBomVersion}")
-    
+    implementation "com.google.firebase:firebase-appcheck-ktx"
     implementation 'com.google.firebase:firebase-appcheck-safetynet'
 }


### PR DESCRIPTION
SafetyNet is deprecated and no longer accepts new projects. New projects should use App Check with Play Integrity instead and existing apps using SafetyNet should migrate to Play Integrity before the shutdown deadline. See the deprecation timeline for more information. App Check will continue to support existing SafetyNet projects until June 2023, after which, SafetyNet configurations will be frozen and unmodifiable. After June 2024, all SafetyNet features will be permanently shut down and removed.