### PR TITLE
fix(ios): cleaning firebase-messaging-core iOS build warnings

### DIFF
--- a/packages/firebase-messaging-core/platforms/ios/src/NSCUNUserNotificationCenterDelegate.swift
+++ b/packages/firebase-messaging-core/platforms/ios/src/NSCUNUserNotificationCenterDelegate.swift
@@ -76,7 +76,13 @@ public class NSCUNUserNotificationCenterDelegate: NSObject, UNUserNotificationCe
         
         if (NSCFirebaseMessagingCore.showNotificationsWhenInForeground || notification.request.content.userInfo["gcm.notification.showWhenInForeground"] as? String == "true" || notification.request.content.userInfo["showWhenInForeground"] as? Bool ?? false ||
             aps != nil && aps?["showWhenInForeground"] as? Bool ?? false) {
-            options = UNNotificationPresentationOptions(rawValue: UNNotificationPresentationOptions.alert.rawValue | UNNotificationPresentationOptions.sound.rawValue | UNNotificationPresentationOptions.badge.rawValue )
+            var alertOptions: UInt = 0
+            if #available(iOS 14.0, *) {
+                alertOptions = UNNotificationPresentationOptions.list.rawValue | UNNotificationPresentationOptions.banner.rawValue
+            } else {
+                alertOptions = UNNotificationPresentationOptions.alert.rawValue
+            }
+            options = UNNotificationPresentationOptions(rawValue: alertOptions |  UNNotificationPresentationOptions.sound.rawValue | UNNotificationPresentationOptions.badge.rawValue)
         }
         
         if (notification.request.content.userInfo["gcm.message_id"] != nil) {


### PR DESCRIPTION
`UNNotificationPresentationOptions.alert` is deprecated since iOS 14.0. This commit aims to fix this following the official documentation.

> Deprecated
> Use [list](https://developer.apple.com/documentation/usernotifications/unnotificationpresentationoptions/list) and [banner](https://developer.apple.com/documentation/usernotifications/unnotificationpresentationoptions/banner) instead.

https://developer.apple.com/documentation/usernotifications/unnotificationpresentationoptions/alert