### PR TITLE
[@nativescript/firebase-messaging-core] feat: support async callbacks for messages and notification taps

### DIFF
--- a/packages/firebase-messaging-core/platforms/ios/src/NSCFirebaseMessagingCore.h
+++ b/packages/firebase-messaging-core/platforms/ios/src/NSCFirebaseMessagingCore.h
@@ -2,7 +2,7 @@
 #import <UIKit/UIKit.h>
 
 typedef void(^BoolCallback)(BOOL success, NSError* _Nullable error);
-typedef void(^DictionaryCallback)(NSDictionary* _Nullable value);
+typedef void(^CompletableDictionaryCallback)(NSDictionary* _Nullable value, void(^_Nonnull complete)(void));
 typedef void(^StringCallback)(NSString* _Nullable value);
 
 @interface NSCFirebaseMessagingCore: NSObject
@@ -11,9 +11,9 @@ typedef void(^StringCallback)(NSString* _Nullable value);
 
 @property (nonatomic, strong, class) BoolCallback _Nullable registerDeviceForRemoteMessagesCallback;
 
-@property (nonatomic, strong, class) DictionaryCallback _Nullable onNotificationTapCallback;
+@property (nonatomic, strong, class) CompletableDictionaryCallback _Nullable onNotificationTapCallback;
 
-@property (nonatomic, strong, class) DictionaryCallback _Nullable onMessageCallback;
+@property (nonatomic, strong, class) CompletableDictionaryCallback _Nullable onMessageCallback;
 
 @property (nonatomic, strong, class) StringCallback _Nullable onTokenCallback;
 

--- a/packages/firebase-messaging-core/platforms/ios/src/NSCFirebaseMessagingCore.m
+++ b/packages/firebase-messaging-core/platforms/ios/src/NSCFirebaseMessagingCore.m
@@ -3,8 +3,8 @@
 
 BOOL ShowNotificationsWhenInForeground = NO;
 BoolCallback RegisterDeviceForRemoteMessagesCallback = nil;
-DictionaryCallback OnNotificationTapCallback = nil;
-DictionaryCallback OnMessageCallback = nil;
+CompletableDictionaryCallback OnNotificationTapCallback = nil;
+CompletableDictionaryCallback OnMessageCallback = nil;
 StringCallback OnTokenCallback = nil;
 
 + (void)setShowNotificationsWhenInForeground:(BOOL)showNotificationsWhenInForeground {
@@ -23,19 +23,19 @@ StringCallback OnTokenCallback = nil;
     RegisterDeviceForRemoteMessagesCallback = callback;
 }
 
-+ (DictionaryCallback)onNotificationTapCallback {
++ (CompletableDictionaryCallback)onNotificationTapCallback {
     return OnNotificationTapCallback;
 }
 
-+ (void)setOnNotificationTapCallback:(DictionaryCallback)callback {
++ (void)setOnNotificationTapCallback:(CompletableDictionaryCallback)callback {
     OnNotificationTapCallback = callback;
 }
 
-+ (DictionaryCallback)onMessageCallback {
++ (CompletableDictionaryCallback)onMessageCallback {
     return OnMessageCallback;
 }
 
-+ (void)setOnMessageCallback:(DictionaryCallback)callback {
++ (void)setOnMessageCallback:(CompletableDictionaryCallback)callback {
     OnMessageCallback = callback;
 }
 

--- a/packages/firebase-messaging-core/platforms/ios/src/NSCUIApplicationDelegate.swift
+++ b/packages/firebase-messaging-core/platforms/ios/src/NSCUIApplicationDelegate.swift
@@ -149,9 +149,9 @@ public class NSCUIApplicationDelegate: UIResponder , UIApplicationDelegate {
         message = parseRemoteMessage(userInfo)
         #endif
         message["foreground"] = application.applicationState == UIApplication.State.active
-        NSCFirebaseMessagingCore.onMessageCallback?(message)
-        completionHandler(.newData)
-        
+        NSCFirebaseMessagingCore.onMessageCallback?(message) {
+            completionHandler(.newData)
+        }
     }
     
 }

--- a/packages/firebase-messaging-core/platforms/ios/src/NSCUNUserNotificationCenterDelegate.swift
+++ b/packages/firebase-messaging-core/platforms/ios/src/NSCUNUserNotificationCenterDelegate.swift
@@ -53,12 +53,16 @@ public class NSCUNUserNotificationCenterDelegate: NSObject, UNUserNotificationCe
         if (remoteNotification["gcm.message_id"] != nil) {
             var message = parseNotification(response.notification)
             message["foreground"] = UIApplication.shared.applicationState == UIApplication.State.active
-            NSCFirebaseMessagingCore.onNotificationTapCallback?(message)
+            NSCFirebaseMessagingCore.onNotificationTapCallback?(message) {
+                completionHandler()
+            }
         }else {
             if((response.notification.request.trigger as? UNPushNotificationTrigger) != nil){
                 var message = remoteNotification
                 message["foreground"] = UIApplication.shared.applicationState == UIApplication.State.active
-                NSCFirebaseMessagingCore.onNotificationTapCallback?(message)
+                NSCFirebaseMessagingCore.onNotificationTapCallback?(message) {
+                    completionHandler()
+                }
             }
         }
         
@@ -82,18 +86,22 @@ public class NSCUNUserNotificationCenterDelegate: NSObject, UNUserNotificationCe
         if (notification.request.content.userInfo["gcm.message_id"] != nil) {
             var message = parseNotification(notification)
             if (message["contentAvailable"] == nil) {
-                NSCFirebaseMessagingCore.onMessageCallback?(message)
+                NSCFirebaseMessagingCore.onMessageCallback?(message) {
+                    completionHandler(options)
+                }
                 message["foreground"] = UIApplication.shared.applicationState == UIApplication.State.active
+            } else {
+                completionHandler(options)
             }
-            completionHandler(options)
             return
         }else {
             if((notification.request.trigger as? UNPushNotificationTrigger) != nil){
                 
                 var message = notification.request.content.userInfo
                 message["foreground"] = UIApplication.shared.applicationState == UIApplication.State.active
-                NSCFirebaseMessagingCore.onMessageCallback?(message)
-                completionHandler(options)
+                NSCFirebaseMessagingCore.onMessageCallback?(message) {
+                    completionHandler(options)
+                }
                 return
             }
         }

--- a/packages/firebase-messaging/typings/objc!NSCFirebaseMessagingCore.d.ts
+++ b/packages/firebase-messaging/typings/objc!NSCFirebaseMessagingCore.d.ts
@@ -5,9 +5,9 @@ declare class NSCFirebaseMessagingCore extends NSObject {
 
 	static new(): NSCFirebaseMessagingCore; // inherited from NSObject
 
-	static onMessageCallback: (p1: NSDictionary<any, any>) => void;
+	static onMessageCallback: (p1: NSDictionary<any, any>, p2: () => void) => void;
 
-	static onNotificationTapCallback: (p1: NSDictionary<any, any>) => void;
+	static onNotificationTapCallback: (p1: NSDictionary<any, any>, p2: () => void) => void;
 
 	static onTokenCallback: (p1: string) => void;
 


### PR DESCRIPTION
On iOS, after all registered callbacks for `onMessage` and `onNotificationTap` events are triggered, the `completionHandler` is called. However, when a callback returns a promise, the plugin doesn't wait for it to be settled but instead calls the `completionHandler` right away. This causes iOS to take away execution time from the app if it is in the background, even though it is still within the granted 30 seconds [as per docs](https://developer.apple.com/documentation/backgroundtasks/choosing-background-strategies-for-your-app?language=objc), essentially delaying the promise to settle until the next time the app is given execution time.

With these changes, the `completionHandler` is called only after all promises have settled.