### PR TITLE
fix(core): initializeApp default app not resolved

### DIFF
--- a/packages/firebase-core/index.android.ts
+++ b/packages/firebase-core/index.android.ts
@@ -313,7 +313,8 @@ export class Firebase {
 					app = com.google.firebase.FirebaseApp.initializeApp(Utils.android.getApplicationContext(), nativeOptions.build(), name);
 				} else {
 					if (defaultApp) {
-						return defaultApp;
+						resolve(defaultApp);
+            return;
 					}
 					isDefault = true;
 					if (nativeOptions) {

--- a/packages/firebase-core/index.ios.ts
+++ b/packages/firebase-core/index.ios.ts
@@ -381,7 +381,8 @@ export class Firebase {
 						app = FIRApp.appNamed(name);
 					} else {
 						if (defaultApp) {
-							return defaultApp;
+              resolve(defaultApp);
+              return;
 						}
 
 						if (nativeOptions) {


### PR DESCRIPTION
When hot reloading using HMR, the default app is already set and is not resolved correctly.